### PR TITLE
Persist activities with SQLModel (DB scaffold + models)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,9 @@
 fastapi
 uvicorn
+
+# Database and ORM
+sqlmodel
+SQLAlchemy
+alembic
+# For Postgres support in production (optional, used when DATABASE_URL points to Postgres)
+psycopg2-binary

--- a/src/app.py
+++ b/src/app.py
@@ -1,81 +1,115 @@
-"""
-High School Management System API
+"""Mergington High School - API backed by SQLModel persisted storage.
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
+This version replaces the in-memory activities dict with a small SQLite
+backed (configurable) database using SQLModel. By default it will create
+`./dev.db` locally. You can set `DATABASE_URL` to a postgres URL for
+production.
 """
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
 from pathlib import Path
+from typing import Dict
 
-app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+from sqlmodel import select
 
-# Mount the static files directory
+from .db import create_db_and_tables, get_session
+from .models import Activity, Signup
+
+
+app = FastAPI(
+    title="Mergington High School API",
+    description="API for viewing and signing up for extracurricular activities",
+)
+
+# Mount static files (same as before)
 current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app.mount("/static", StaticFiles(directory=current_dir / "static"), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+
+def _initial_activity_data() -> Dict[str, dict]:
+    # Original seed data preserved here for the initial migration
+    return {
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+        },
+        "Soccer Team": {
+            "description": "Join the school soccer team and compete in matches",
+            "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+            "max_participants": 22,
+            "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+        },
+        "Basketball Team": {
+            "description": "Practice and play basketball with the school team",
+            "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+        },
+        "Art Club": {
+            "description": "Explore your creativity through painting and drawing",
+            "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+            "max_participants": 15,
+            "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+        },
+        "Drama Club": {
+            "description": "Act, direct, and produce plays and performances",
+            "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+            "max_participants": 20,
+            "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+        },
+        "Math Club": {
+            "description": "Solve challenging problems and participate in math competitions",
+            "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+            "max_participants": 10,
+            "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+        },
+        "Debate Team": {
+            "description": "Develop public speaking and argumentation skills",
+            "schedule": "Fridays, 4:00 PM - 5:30 PM",
+            "max_participants": 12,
+            "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+        },
     }
-}
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    # Create DB/tables and seed initial activities if empty
+    create_db_and_tables()
+    with get_session() as session:
+        activity_count = session.exec(select(Activity)).first()
+        if activity_count is None:
+            seed = _initial_activity_data()
+            for name, info in seed.items():
+                activity = Activity(
+                    name=name,
+                    description=info["description"],
+                    schedule=info["schedule"],
+                    max_participants=info["max_participants"],
+                )
+                session.add(activity)
+                session.commit()
+                # add pre-existing participants as signups
+                for email in info.get("participants", []):
+                    signup = Signup(activity_id=activity.id, email=email)
+                    session.add(signup)
+                session.commit()
 
 
 @app.get("/")
@@ -85,48 +119,62 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    """Return activities in the same shape as the original API to avoid
+    changing the frontend.
+    """
+    with get_session() as session:
+        activities = {}
+        results = session.exec(select(Activity)).all()
+        for act in results:
+            # fetch signups for this activity
+            signups = session.exec(select(Signup).where(Signup.activity_id == act.id)).all()
+            participants = [s.email for s in signups]
+            activities[act.name] = {
+                "description": act.description,
+                "schedule": act.schedule,
+                "max_participants": act.max_participants,
+                "participants": participants,
+            }
+        return activities
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    """Sign up a student for an activity (persisted)."""
+    with get_session() as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # current participants
+        signups = session.exec(select(Signup).where(Signup.activity_id == activity.id)).all()
+        participants = [s.email for s in signups]
+        if email in participants:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        if len(participants) >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        signup = Signup(activity_id=activity.id, email=email)
+        session.add(signup)
+        session.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    """Unregister a student from an activity (persisted)."""
+    with get_session() as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        signup = session.exec(
+            select(Signup).where((Signup.activity_id == activity.id) & (Signup.email == email))
+        ).first()
+        if not signup:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        session.delete(signup)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,16 @@
+from sqlmodel import SQLModel, create_engine, Session
+import os
+
+# Allow overriding DB via DATABASE_URL env var (e.g., postgres://...)
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./dev.db")
+
+# echo SQL for debugging when needed
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+def create_db_and_tables() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    return Session(engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Activity(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True, unique=True)
+    description: str
+    schedule: str
+    max_participants: int = 0
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    signups: List["Signup"] = Relationship(back_populates="activity")
+
+
+class Signup(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    activity_id: int = Field(foreign_key="activity.id")
+    email: str = Field(index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    activity: Optional[Activity] = Relationship(back_populates="signups")


### PR DESCRIPTION
This PR adds initial persistence for activities and signups using SQLModel.

Changes:
- Add `src/db.py` with engine and session helpers (defaults to sqlite `./dev.db`, configurable via `DATABASE_URL`).
- Add `src/models.py` with `Activity` and `Signup` SQLModel models.
- Replace in-memory activities in `src/app.py` with SQLModel-backed storage, and seed initial activities on startup if none exist.
- Update `requirements.txt` with database dependencies (sqlmodel, SQLAlchemy, alembic, psycopg2-binary).

Notes and next steps:
- This is an initial scaffold. For production Postgres and migrations, configure `DATABASE_URL` and add Alembic migrations (not included yet).
- I kept the `/activities` response shape identical to avoid frontend changes.

Please review and let me know any changes you want before I expand this (migrations, auth, tests).